### PR TITLE
Fix compiling errors in test.

### DIFF
--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -181,7 +181,7 @@ func TestDeleteTransact(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(os.Getenv("DOCKER_IP"), int(6640))
+	ovs, err := Connect(os.Getenv("DOCKER_IP"), int(6640), PROTOCOL)
 	if err != nil {
 		log.Fatal("Failed to Connect. error:", err)
 		panic(err)
@@ -483,7 +483,7 @@ func TestMonitorCancel(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(os.Getenv("DOCKER_IP"), int(6640))
+	ovs, err := Connect(os.Getenv("DOCKER_IP"), int(6640), PROTOCOL)
 	if err != nil {
 		log.Fatal("Failed to Connect. error:", err)
 		panic(err)


### PR DESCRIPTION
./ovs_integration_test.go:184:21: not enough arguments in call to Connect
    have (string, int)
    want (string, int, string)
./ovs_integration_test.go:486:21: not enough arguments in call to Connect
    have (string, int)
    want (string, int, string)