### PR TITLE
README.md: Remove out-of-date links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 libovsdb
 ========
 
-[![Circle CI](https://circleci.com/gh/socketplane/libovsdb.png?style=badge&circle-token=17838d6362be941ed8478bf9d10de5307d4b917d)](https://circleci.com/gh/socketplane/libovsdb) [![Coverage Status](https://coveralls.io/repos/socketplane/libovsdb/badge.png?branch=master)](https://coveralls.io/r/socketplane/libovsdb?branch=master)
-
 An OVSDB Library written in Go
 
 ## Purpose of Fork of Original libovsdb


### PR DESCRIPTION
The badges links were for the old socketplane CI and Coverage settings, which are not working any more. New links can be added when new CI/Coverage are setup properly.