### PR TITLE
Fix broken ssl/tcp in universal Connect:

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package libovsdb
+
+import (
+	"crypto/tls"
+)
+
+type Config struct {
+	Addr         string
+	TLSConfig    *tls.Config
+}
+


### PR DESCRIPTION
1. Commit df4f42ff0dbc7ccda2df8ca093f129ad686d2c51 broke ovn connect
       using ssl/tcp when using universal connect method for all unix, ssl and
       tcp. To connect using ssl/tcp, we need to parse host
       e.g. tcp:10.x.x.x:6641 fails to be parsed by url.Parse.
       This commit fixes the same.

2. Also fix the UTs since libovsdb is tied to ovsdb and not ovndbs