### PR TITLE
client: Fix errors.New() arguments.

### DIFF
--- a/client.go
+++ b/client.go
@@ -250,7 +250,7 @@ func (ovs OvsdbClient) Transact(database string, operation ...Operation) ([]Oper
 	var reply []OperationResult
 	db, ok := ovs.Schema[database]
 	if !ok {
-		return nil, errors.New("invalid Database %q Schema", database)
+		return nil, errors.New(fmt.Sprintf("invalid Database %q Schema", database))
 	}
 
 	if ok := db.validateOperations(operation...); !ok {
@@ -269,7 +269,7 @@ func (ovs OvsdbClient) Transact(database string, operation ...Operation) ([]Oper
 func (ovs OvsdbClient) MonitorAll(database string, jsonContext interface{}) (*TableUpdates, error) {
 	schema, ok := ovs.Schema[database]
 	if !ok {
-		return nil, errors.New("invalid Database %q Schema", database)
+		return nil, errors.New(fmt.Sprintf("invalid Database %q Schema", database))
 	}
 
 	requests := make(map[string]MonitorRequest)


### PR DESCRIPTION
CI failed because of "too many arguments in call to errors.New".

Fixes: b02798bdeab ("client: make "invalid Database Schema" message more informative")
Signed-off-by: Han Zhou <hzhou8@ebay.com>