### PR TITLE
Allow libovsdb to connnect to ovsdb instance over IPv6 connection.

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,13 +65,11 @@ func Connect(endpoints string, tlsConfig *tls.Config) (*OvsdbClient, error) {
 		if u, err = url.Parse(endpoint); err != nil {
 			return nil, err
 		}
-		var host string
-		endPointStr := strings.Split(endpoint, ":")
-		if len(endPointStr) > 2 {
-			host = fmt.Sprintf("%s:%s", endPointStr[1], endPointStr[2])
-			if len(host) == 0 {
-				host = defaultTCPAddress
-			}
+		// u.Opaque contains the original endPoint with the leading protocol stripped
+		// off. For example: endPoint is "tcp:127.0.0.1:6640" and u.Opaque is "127.0.0.1:6640"
+		host := u.Opaque
+		if len(host) == 0 {
+			host = defaultTCPAddress
 		}
 		switch u.Scheme {
 		case UNIX:


### PR DESCRIPTION
When trying to connect to an ovsdb instance via IPv6, encountered an IPv6
parsing issue. In the logic to strip off the leading protocol (i.e. tcp:...),
the code uses strings.Split(endpoint, ":"), which does not take into account
the ':' in an IPv6 address.

Updated the code to use strings.SplitN(endpoint, ":", 2) instead.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>