### PR TITLE
remove RowUpdate`UUID field

### DIFF
--- a/notation.go
+++ b/notation.go
@@ -81,9 +81,8 @@ type TableUpdate struct {
 
 // RowUpdate represents a row update according to RFC7047
 type RowUpdate struct {
-	UUID UUID `json:"-,omitempty"`
-	New  Row  `json:"new,omitempty"`
-	Old  Row  `json:"old,omitempty"`
+	New Row `json:"new,omitempty"`
+	Old Row `json:"old,omitempty"`
 }
 
 // OvsdbError is an OVS Error Condition


### PR DESCRIPTION
the UUID field in RowUpdate struct is not used and currently holds an
incorrect value of ["named-uuid", ""].

 per RFC 7047, the update notification from ovsdb-server has row-update,
 and it is defined to be an object with the following members:

   "old": <row>   present for "delete" and "modify" updates
   "new": <row>   present for "initial", "insert", and "modify" updates

the UUID for row is already captured as TableUpdate`Rows map, so remove
this  key altogether.

at scale, with 1000s and 1000s of entries small things like this will
add up.

@hzhou8 @vtolstov PTAL