### PR TITLE
cleanup resources on failure and API should not exit the program on error

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/url"
 	"reflect"
@@ -107,14 +106,16 @@ func newRPC2Client(conn net.Conn) (*OvsdbClient, error) {
 
 	// Process Async Notifications
 	dbs, err := ovs.ListDbs()
-	if err == nil {
-		for _, db := range dbs {
-			schema, err := ovs.GetSchema(db)
-			if err == nil {
-				ovs.Schema[db] = *schema
-			} else {
-				return nil, err
-			}
+	if err != nil {
+		return nil, err
+	}
+
+	for _, db := range dbs {
+		schema, err := ovs.GetSchema(db)
+		if err == nil {
+			ovs.Schema[db] = *schema
+		} else {
+			return nil, err
 		}
 	}
 	return ovs, nil
@@ -238,7 +239,7 @@ func (ovs OvsdbClient) ListDbs() ([]string, error) {
 	var dbs []string
 	err := ovs.rpcClient.Call("list_dbs", nil, &dbs)
 	if err != nil {
-		log.Fatal("ListDbs failure", err)
+		return nil, fmt.Errorf("ListDbs failure - %v", err)
 	}
 	return dbs, err
 }


### PR DESCRIPTION
This PR addresses following issues:

 -  cleanup the underlying rpc client on erros in newRPC2Client()
    
    currently we don't close the RPC connection on failures and also
    don't remove the stale RPC client connection from the `connections`
    map

- ListDbs API should not exit the program on error
    
    it could be that the users of the API may want to re-try, so the
    library API shouldn't exit on error


@hzhou8 @noah8713 @vtolstov PTAL