### PR TITLE
Serveral Minor fixes 

### DIFF
--- a/client.go
+++ b/client.go
@@ -183,7 +183,7 @@ func echo(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
 
 // RFC 7047 : Update Notification Section 4.1.6
 // Processing "params": [<json-value>, <table-updates>]
-func update(client *rpc2.Client, params []interface{}, reply *interface{}) error {
+func update(client *rpc2.Client, params []interface{}, _ *interface{}) error {
 	if len(params) < 2 {
 		return errors.New("Invalid Update message")
 	}

--- a/client.go
+++ b/client.go
@@ -291,7 +291,7 @@ func (ovs OvsdbClient) MonitorAll(database string, jsonContext interface{}) (*Ta
 
 // MonitorCancel will request cancel a previously issued monitor request
 // RFC 7047 : monitor_cancel
-func (ovs OvsdbClient) MonitorCancel(database string, jsonContext interface{}) error {
+func (ovs OvsdbClient) MonitorCancel(jsonContext interface{}) error {
 	var reply OperationResult
 
 	args := NewMonitorCancelArgs(jsonContext)

--- a/client.go
+++ b/client.go
@@ -92,7 +92,7 @@ func Connect(endpoints string, tlsConfig *tls.Config) (*OvsdbClient, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("failed to connect: %s", err.Error())
+	return nil, fmt.Errorf("failed to connect to endpoints %q: %v", endpoints, err)
 }
 
 func newRPC2Client(conn net.Conn) (*OvsdbClient, error) {

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -524,7 +524,7 @@ func TestMonitorCancel(t *testing.T) {
 
 	ovs.Monitor("Open_vSwitch", monitorID, requests)
 
-	err = ovs.MonitorCancel("Open_vSwitch", monitorID)
+	err = ovs.MonitorCancel(monitorID)
 
 	if err != nil {
 		t.Error("MonitorCancel operation failed with error=", err)

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -327,7 +327,7 @@ func TestRemoveNotify(t *testing.T) {
 	ovs.Register(notifier)
 
 	lenIni := len(ovs.handlers)
-	ovs.Unregister(notifier)
+	_ = ovs.Unregister(notifier)
 	lenEnd := len(ovs.handlers)
 
 	if lenIni == lenEnd {
@@ -341,7 +341,7 @@ type Notifier struct {
 	echoChan chan bool
 }
 
-func (n Notifier) Update(context interface{}, tableUpdates TableUpdates) {
+func (n Notifier) Update(interface{}, TableUpdates) {
 }
 func (n Notifier) Locked([]interface{}) {
 }
@@ -350,7 +350,7 @@ func (n Notifier) Stolen([]interface{}) {
 func (n Notifier) Echo([]interface{}) {
 	n.echoChan <- true
 }
-func (n Notifier) Disconnected(client *OvsdbClient) {
+func (n Notifier) Disconnected(*OvsdbClient) {
 }
 
 func TestDBSchemaValidation(t *testing.T) {
@@ -522,7 +522,7 @@ func TestMonitorCancel(t *testing.T) {
 			Modify:  true,
 		}}
 
-	ovs.Monitor("Open_vSwitch", monitorID, requests)
+	_, _ = ovs.Monitor("Open_vSwitch", monitorID, requests)
 
 	err = ovs.MonitorCancel(monitorID)
 


### PR DESCRIPTION
This PR includes several minor fixes:

- miscellaneous fixes to handle unused parameter and unhandled errors
- MonitorCancel API only needs jsonContext to match the previous monitor
- fix unhandled error in Disconnect()
- call to 'err.Error()' may lead to nil pointer dereference in Connect

@hzhou8 @noah8713 @vtolstov PTAL