### PR TITLE
test: fix access to ovsdb in local-test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,5 @@ test:
   working_dir: /go/src/github.com/socketplane/libovsdb
   environment:
     DOCKER_IP: "ovs"
+    OVS_DB: "tcp:ovs:6640"
   command: "make test-local"

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -26,6 +26,8 @@ func SetConfig() {
 	var ovsDb = os.Getenv("OVS_DB")
 	if ovsDb == "" {
 		cfg.Addr = "unix:" + ovsRunDir + "/" + defOvsSocket
+	} else {
+		cfg.Addr = ovsDb
 	}
 }
 


### PR DESCRIPTION
Export the OVS_DB env var in docker-compose and use it in unit tests to fix local-tests

Fixes: #25 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>