### PR TITLE
Add ORM API

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,223 @@
+package libovsdb
+
+import "fmt"
+
+var (
+	aString  = "foo"
+	aEnum    = "enum1"
+	aEnumSet = []string{"enum1", "enum2", "enum3"}
+	aSet     = []string{"a", "set", "of", "strings"}
+	aUUID0   = "2f77b348-9768-4866-b761-89d5177ecda0"
+	aUUID1   = "2f77b348-9768-4866-b761-89d5177ecda1"
+	aUUID2   = "2f77b348-9768-4866-b761-89d5177ecda2"
+	aUUID3   = "2f77b348-9768-4866-b761-89d5177ecda3"
+
+	aUUIDSet = []string{
+		aUUID0,
+		aUUID1,
+		aUUID2,
+		aUUID3,
+	}
+
+	aIntSet = []int{
+		0,
+		1,
+		2,
+		3,
+	}
+	aFloat = 42.00
+
+	aFloatSet = []float64{
+		3.14,
+		2.71,
+		42.0,
+	}
+
+	aMap = map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+
+	aEmptySet = []string{}
+)
+
+var testSchema = []byte(`{
+  "cksum": "223619766 22548",
+  "name": "TestSchema",
+  "tables": {
+    "TestTable": {
+      "columns": {
+        "aString": {
+          "type": "string"
+        },
+        "aSet": {
+          "type": {
+            "key": "string",
+            "max": "unlimited",
+            "min": 0
+          }
+        },
+        "aSingleSet": {
+          "type": {
+            "key": "string",
+            "max": "unlimited",
+            "min": 0,
+            "max": 1
+          }
+        },
+        "aUUIDSet": {
+          "type": {
+            "key": {
+              "refTable": "SomeOtherTAble",
+              "refType": "weak",
+              "type": "uuid"
+            },
+            "min": 0
+          }
+        },
+        "aUUID": {
+          "type": {
+            "key": {
+              "refTable": "SomeOtherTAble",
+              "refType": "weak",
+              "type": "uuid"
+            },
+            "min": 1,
+            "max": 1
+          }
+        },
+        "aIntSet": {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
+        "aFloat": {
+          "type": {
+            "key": {
+              "type": "real"
+            }
+          }
+        },
+        "aFloatSet": {
+          "type": {
+            "key": {
+              "type": "real"
+            },
+            "min": 0,
+            "max": 10
+          }
+        },
+        "aEmptySet": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
+        "aEnum": {
+          "type": {
+            "key": {
+              "enum": [
+                "set",
+                [
+                  "enum1",
+                  "enum2",
+                  "enum3"
+                ]
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "aMap": {
+          "type": {
+            "key": "string",
+            "max": "unlimited",
+            "min": 0,
+            "value": "string"
+          }
+	}
+      }
+    }
+  }
+}`)
+
+// When going Native -> OvS:
+//	map -> *OvsMap
+//	slice -> *OvsSet
+// However, when going OvS -> Native
+//	OvsMap -> map
+//	OvsSet -> slice
+// Perform indirection of ovs fields to be compared
+// with the ones that wre used initially
+func expectedOvs(in interface{}) interface{} {
+	switch in.(type) {
+	case *OvsSet:
+		return *(in.(*OvsSet))
+	case *OvsMap:
+		return *(in.(*OvsMap))
+	default:
+		return in
+	}
+}
+
+func getNativeTestMap() map[string]interface{} {
+	return map[string]interface{}{
+		"aString":    aString,
+		"aSet":       aSet,
+		"ASingleSet": []string{aString},
+		"aUUIDSet":   aUUIDSet,
+		"aMap":       aMap,
+		"aFloat":     aFloat,
+		"aFloatSet":  aFloatSet,
+		"aUUID":      aUUID0,
+		"aIntSet":    aIntSet,
+	}
+}
+
+func getOvsTestRow() Row {
+	ovsRow := Row{Fields: make(map[string]interface{})}
+	ovsRow.Fields["aString"] = aString
+	s, _ := NewOvsSet(aSet)
+	ovsRow.Fields["aSet"] = *s
+
+	// Set's can hold the value if they have len == 1
+	ovsRow.Fields["aSingleSet"] = aString
+
+	us := make([]UUID, 0)
+	for _, u := range aUUIDSet {
+		us = append(us, UUID{GoUUID: u})
+	}
+	ovsUs, _ := NewOvsSet(us)
+	ovsRow.Fields["aUUIDSet"] = *ovsUs
+
+	ovsRow.Fields["aUUID"] = UUID{GoUUID: aUUID0}
+
+	is, e := NewOvsSet(aIntSet)
+	if e != nil {
+		fmt.Printf("%s", e.Error())
+	}
+	ovsRow.Fields["aIntSet"] = *is
+
+	ovsRow.Fields["aFloat"] = aFloat
+
+	fs, e := NewOvsSet(aFloatSet)
+	ovsRow.Fields["aFloatSet"] = *fs
+
+	es, e := NewOvsSet([]string{})
+	ovsRow.Fields["aEmptySet"] = *es
+
+	ovsRow.Fields["aEnum"] = aEnum
+
+	m, _ := NewOvsMap(aMap)
+	ovsRow.Fields["aMap"] = *m
+
+	return ovsRow
+}

--- a/api_test.go
+++ b/api_test.go
@@ -27,6 +27,8 @@ var (
 	}
 	aFloat = 42.00
 
+	aInt = 42
+
 	aFloatSet = []float64{
 		3.14,
 		2.71,

--- a/bindings.go
+++ b/bindings.go
@@ -218,3 +218,36 @@ func NativeToOvs(column *ColumnSchema, rawElem interface{}) (interface{}, error)
 		panic(fmt.Sprintf("Unknown Type: %v", column.Type))
 	}
 }
+
+// IsDefaultValue checks if a provided native element corresponds to the default value of its
+// designated column type
+func IsDefaultValue(column *ColumnSchema, nativeElem interface{}) bool {
+	switch column.Type {
+	case TypeEnum:
+		return isDefaultBaseValue(nativeElem, column.TypeObj.Key.Type)
+	default:
+		return isDefaultBaseValue(nativeElem, column.Type)
+	}
+}
+
+func isDefaultBaseValue(elem interface{}, etype ExtendedType) bool {
+	value := reflect.ValueOf(elem)
+	if !value.IsValid() {
+		return true
+	}
+
+	switch etype {
+	case TypeUUID:
+		return elem.(string) == "00000000-0000-0000-0000-000000000000" || elem.(string) == ""
+	case TypeMap, TypeSet:
+		return value.IsNil() || value.Len() == 0
+	case TypeString:
+		return elem.(string) == ""
+	case TypeInteger:
+		return elem.(int) == 0
+	case TypeReal:
+		return elem.(float64) == 0
+	default:
+		return false
+	}
+}

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -7,62 +7,6 @@ import (
 	"testing"
 )
 
-var (
-	aString  = "foo"
-	aEnum    = "enum1"
-	aEnumSet = []string{"enum1", "enum2", "enum3"}
-	aSet     = []string{"a", "set", "of", "strings"}
-	aUUID0   = "2f77b348-9768-4866-b761-89d5177ecda0"
-	aUUID1   = "2f77b348-9768-4866-b761-89d5177ecda1"
-	aUUID2   = "2f77b348-9768-4866-b761-89d5177ecda2"
-	aUUID3   = "2f77b348-9768-4866-b761-89d5177ecda3"
-
-	aUUIDSet = []string{
-		aUUID0,
-		aUUID1,
-		aUUID2,
-		aUUID3,
-	}
-
-	aIntSet = []int{
-		0,
-		1,
-		2,
-		3,
-	}
-	aFloat = 42.00
-
-	aFloatSet = []float64{
-		3.14,
-		2.71,
-		42.0,
-	}
-
-	aMap = map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-		"key3": "value3",
-	}
-
-	aEmptySet = []string{}
-)
-
-func getColnames() []string {
-	return []string{
-		"aString",
-		"aSet",
-		"anotherSet",
-		"aUUIDSet",
-		"aIntSet",
-		"aFloat",
-		"aFloatSet",
-		"aMap",
-		"aUUID",
-		"aEmptySet",
-		"aEnum",
-	}
-}
-
 type Transformation map[string]interface{}
 
 func (t Transformation) String() string {

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -427,3 +427,203 @@ func TestNativeToOvsErr(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDefault(t *testing.T) {
+	type Test struct {
+		name     string
+		column   []byte
+		elem     interface{}
+		expected bool
+	}
+	tests := []Test{
+		{
+			name:     "empty string",
+			column:   []byte(`{"type":"string"}`),
+			elem:     "",
+			expected: true,
+		},
+		{
+			name:     "non string",
+			column:   []byte(`{"type":"string"}`),
+			elem:     "something",
+			expected: false,
+		},
+		{
+			name:     "empty uuid",
+			column:   []byte(`{"type":"uuid"}`),
+			elem:     "",
+			expected: true,
+		},
+		{
+			name:     "default uuid",
+			column:   []byte(`{"type":"uuid"}`),
+			elem:     "00000000-0000-0000-0000-000000000000",
+			expected: true,
+		},
+		{
+			name:     "non-empty uuid",
+			column:   []byte(`{"type":"uuid"}`),
+			elem:     aUUID0,
+			expected: false,
+		},
+		{
+			name:     "zero int",
+			column:   []byte(`{"type":"integer"}`),
+			elem:     0,
+			expected: true,
+		},
+		{
+			name:     "non-zero int",
+			column:   []byte(`{"type":"integer"}`),
+			elem:     42,
+			expected: false,
+		},
+		{
+			name:     "non-zero float",
+			column:   []byte(`{"type":"real"}`),
+			elem:     42.0,
+			expected: false,
+		},
+		{
+			name:     "zero float",
+			column:   []byte(`{"type":"real"}`),
+			elem:     0.0,
+			expected: true,
+		},
+		{
+			name: "empty set ",
+			column: []byte(`{
+					   "type": {
+       					     "key": "string",
+       					     "max": "unlimited",
+       					     "min": 0
+       					   }
+       					 }`),
+			elem:     []string{},
+			expected: true,
+		},
+		{
+			name: "empty set allocated",
+			column: []byte(`{
+					   "type": {
+       					     "key": "string",
+       					     "max": "unlimited",
+       					     "min": 0
+       					   }
+       					 }`),
+			elem:     make([]string, 0, 10),
+			expected: true,
+		},
+		{
+			name: "non-empty set",
+			column: []byte(`{
+					   "type": {
+       					     "key": "string",
+       					     "max": "unlimited",
+       					     "min": 0
+       					   }
+       					 }`),
+			elem:     []string{"something"},
+			expected: false,
+		},
+		{
+			name: "empty map allocated",
+			column: []byte(`{
+					   "type": {
+       					     "key": "string",
+       					     "value": "string"
+       					   }
+       					 }`),
+			elem:     make(map[string]string, 0),
+			expected: true,
+		},
+		{
+			name: "nil map",
+			column: []byte(`{
+					   "type": {
+       					     "key": "string",
+       					     "value": "string"
+       					   }
+       					 }`),
+			elem:     nil,
+			expected: true,
+		},
+		{
+			name: "empty map",
+			column: []byte(`{
+					   "type": {
+       					     "key": "string",
+       					     "value": "string"
+       					   }
+       					 }`),
+			elem:     map[string]string{},
+			expected: true,
+		},
+		{
+			name: "non-empty map",
+			column: []byte(`{
+					   "type": {
+       					     "key": "string",
+       					     "value": "string"
+       					   }
+       					 }`),
+			elem:     map[string]string{"foo": "bar"},
+			expected: false,
+		},
+		{
+			name: "empty enum",
+			column: []byte(`{
+					"type":{
+				            "key": {
+				              "enum": [
+				                "set",
+				                [
+				                  "enum1",
+				                  "enum2",
+				                  "enum3"
+				                ]
+				              ],
+				              "type": "string"
+				            }
+				          }
+					}`),
+			elem:     "",
+			expected: true,
+		},
+		{
+			name: "non-empty enum",
+			column: []byte(`{
+					"type":{
+				            "key": {
+				              "enum": [
+				                "set",
+				                [
+				                  "enum1",
+				                  "enum2",
+				                  "enum3"
+				                ]
+				              ],
+				              "type": "string"
+				            }
+				          }
+					}`),
+			elem:     "enum1",
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("IsDefault: %s", test.name), func(t *testing.T) {
+			var column ColumnSchema
+			if err := json.Unmarshal(test.column, &column); err != nil {
+				t.Fatal(err)
+			}
+
+			result := IsDefaultValue(&column, test.elem)
+			if result != test.expected {
+				t.Errorf("Failed to determine if %v is default. Expected %t got %t", test, test.expected, result)
+				t.Logf("Conversion schema %v", string(test.column))
+			}
+
+		})
+	}
+}

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -23,12 +23,15 @@ func getErrTransMaps() []map[string]interface{} {
 		"native": 42,
 		"ovs":    42,
 	})
+
+	// OVS floats should be convertible to integers since encoding/json will use float64 as
+	// the default numeric type. However, native types should match
 	transMap = append(transMap, map[string]interface{}{
 		"name":   "Wrong Atomic Numeric Type: Int",
 		"schema": []byte(`{"type":"integer"}`),
 		"native": 42.0,
-		"ovs":    42.0,
 	})
+
 	transMap = append(transMap, map[string]interface{}{
 		"name":   "Wrong Atomic Numeric Type: Float",
 		"schema": []byte(`{"type":"real"}`),
@@ -105,6 +108,24 @@ func getTransMaps() []map[string]interface{} {
 		"native2ovs": aFloat,
 		"ovs":        aFloat,
 		"ovs2native": aFloat,
+	})
+
+	// Integers
+	transMap = append(transMap, map[string]interface{}{
+		"name":       "Integers with float ovs type",
+		"schema":     []byte(`{"type":"integer"}`),
+		"native":     aInt,
+		"native2ovs": aInt,
+		"ovs":        aFloat, // Default json encoding uses float64 for all numbers
+		"ovs2native": aInt,
+	})
+	transMap = append(transMap, map[string]interface{}{
+		"name":       "Integers",
+		"schema":     []byte(`{"type":"integer"}`),
+		"native":     aInt,
+		"native2ovs": aInt,
+		"ovs":        aInt,
+		"ovs2native": aInt,
 	})
 
 	// string set
@@ -368,6 +389,9 @@ func TestNativeToOvs(t *testing.T) {
 func TestOvsToNativeErr(t *testing.T) {
 	transMaps := getErrTransMaps()
 	for _, trans := range transMaps {
+		if _, ok := trans["ovs"]; !ok {
+			continue
+		}
 		t.Run(fmt.Sprintf("Ovs To Native Error: %s", trans["name"]), func(t *testing.T) {
 			var column ColumnSchema
 			if err := json.Unmarshal(trans["schema"].([]byte), &column); err != nil {
@@ -386,6 +410,9 @@ func TestOvsToNativeErr(t *testing.T) {
 func TestNativeToOvsErr(t *testing.T) {
 	transMaps := getErrTransMaps()
 	for _, trans := range transMaps {
+		if _, ok := trans["native"]; !ok {
+			continue
+		}
 		t.Run(fmt.Sprintf("Native To Ovs Error: %s", trans["name"]), func(t *testing.T) {
 			var column ColumnSchema
 			if err := json.Unmarshal(trans["schema"].([]byte), &column); err != nil {

--- a/client.go
+++ b/client.go
@@ -371,3 +371,12 @@ func (ovs OvsdbClient) NativeAPI(db string) (*NativeAPI, error) {
 	}
 	return NewNativeAPI(&schema), nil
 }
+
+// ORM returns a ORM API object associated with the provided db name
+func (ovs OvsdbClient) ORM(db string) (*ORMAPI, error) {
+	schema, ok := ovs.Schema[db]
+	if !ok {
+		return nil, fmt.Errorf("Database not found %s", db)
+	}
+	return NewORMAPI(&schema), nil
+}

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -21,6 +21,10 @@ var update chan *libovsdb.TableUpdates
 var cache map[string]map[string]libovsdb.Row
 
 func play(ovs *libovsdb.OvsdbClient) {
+	api, err := ovs.NativeAPI(ovsDb)
+	if err != nil {
+		panic(fmt.Sprintf("Cannot access NativeAPI: %s", err))
+	}
 	go processInput(ovs)
 	for {
 		select {
@@ -28,7 +32,7 @@ func play(ovs *libovsdb.OvsdbClient) {
 			for table, tableUpdate := range currUpdate.Updates {
 				if table == bridgeTable {
 					for uuid, row := range tableUpdate.Rows {
-						rowData, err := ovs.Apis[ovsDb].GetRowData(bridgeTable, &row.New)
+						rowData, err := api.GetRowData(bridgeTable, &row.New)
 						if err != nil {
 							fmt.Println("ERROR getting Bridge Data", err)
 						}
@@ -49,7 +53,11 @@ func play(ovs *libovsdb.OvsdbClient) {
 }
 
 func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
-	api := ovs.Apis[ovsDb]
+	api, err := ovs.NativeAPI(ovsDb)
+	if err != nil {
+		fmt.Printf("Cannot access Native API: %s", err.Error())
+		os.Exit(1)
+	}
 	namedUUID := "gopher"
 	// bridge row to insert
 	bridge := make(map[string]interface{})

--- a/native.go
+++ b/native.go
@@ -38,8 +38,8 @@ type NativeAPI struct {
 }
 
 // NewNativeAPI returns a NativeAPI
-func NewNativeAPI(schema *DatabaseSchema) NativeAPI {
-	return NativeAPI{
+func NewNativeAPI(schema *DatabaseSchema) *NativeAPI {
+	return &NativeAPI{
 		schema: schema,
 	}
 }

--- a/orm.go
+++ b/orm.go
@@ -123,6 +123,10 @@ func (oa ORMAPI) NewRow(tableName string, data interface{}) (map[string]interfac
 		}
 
 		nativeElem := objVal.FieldByName(fieldName)
+		// Omit fields with default or nil value
+		if IsDefaultValue(column, nativeElem.Interface()) {
+			continue
+		}
 		ovsElem, err := NativeToOvs(column, nativeElem.Interface())
 		if err != nil {
 			return nil, fmt.Errorf("Table %s, Column %s: Failed to generate OvS element. %s", tableName, name, err.Error())

--- a/orm.go
+++ b/orm.go
@@ -1,0 +1,188 @@
+package libovsdb
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ORMAPI is an API that offers functions to interact with libovsdb through
+// user-provided native structs. The way to specify what field of the struct goes
+// to what column in the database id through field a field tag.
+// The tag used is "ovs" and has the following structure
+// 'ovn:"${COLUMN_NAME}"'
+//	where COLUMN_NAME is the name of the column and must match the schema
+//
+//Example:
+//  type MyObj struct {
+//  	Name string `ovs:"name"`
+//  }
+type ORMAPI struct {
+	schema *DatabaseSchema
+}
+
+// ErrORM describes an error in an ORM type
+type ErrORM struct {
+	objType   string
+	field     string
+	fieldType string
+	fieldTag  string
+	reason    string
+}
+
+func (e *ErrORM) Error() string {
+	return fmt.Sprintf("ORM Error. Object type %s contains field %s (%s) ovs tag %s: %s",
+		e.objType, e.field, e.fieldType, e.fieldTag, e.reason)
+}
+
+// NewORMAPI returns a new ORM API
+func NewORMAPI(schema *DatabaseSchema) *ORMAPI {
+	return &ORMAPI{
+		schema: schema,
+	}
+}
+
+// GetRowData transforms a Row to a struct based on its tags
+// The result object must be given as pointer to an object with the right tags
+func (oa ORMAPI) GetRowData(tableName string, row *Row, result interface{}) error {
+	if row == nil {
+		return nil
+	}
+	return oa.GetData(tableName, row.Fields, result)
+}
+
+// GetData transforms a map[string]interface{} containing OvS types (e.g: a ResultRow
+// has this format) to ORM struct
+// The result object must be given as pointer to an object with the right tags
+func (oa ORMAPI) GetData(tableName string, ovsData map[string]interface{}, result interface{}) error {
+	table, ok := oa.schema.Tables[tableName]
+	if !ok {
+		return NewErrNoTable(tableName)
+	}
+
+	objPtrVal := reflect.ValueOf(result)
+	if objPtrVal.Type().Kind() != reflect.Ptr {
+		return NewErrWrongType("ORMAPI.GetData", "pointer to a struct", result)
+	}
+
+	objVal := reflect.Indirect(objPtrVal)
+	fields, err := oa.getORMFields(&table, objVal.Type())
+	if err != nil {
+		return err
+	}
+	for name, column := range table.Columns {
+		fieldName, ok := fields[name]
+		if !ok {
+			// If provided struct does not have a field to hold this value, skip it
+			continue
+		}
+
+		ovsElem, ok := ovsData[name]
+		if !ok {
+			// Ignore missing columns
+			continue
+		}
+
+		nativeElem, err := OvsToNative(column, ovsElem)
+		if err != nil {
+			return fmt.Errorf("Table %s, Column %s: Failed to extract native element: %s",
+				tableName, name, err.Error())
+		}
+
+		nativeElemValue := reflect.ValueOf(nativeElem)
+		destFieldValue := objVal.FieldByName(fieldName)
+		if !destFieldValue.Type().AssignableTo(nativeElemValue.Type()) {
+			return fmt.Errorf("Table %s, Column %s: Native value %v (%s) is not assignable to field %s (%s)",
+				tableName, name, nativeElem, nativeElemValue.Type(), fieldName, destFieldValue.Type())
+		}
+		destFieldValue.Set(nativeElemValue)
+	}
+	return nil
+}
+
+// NewRow transforms an ORM struct to a map[string] interface{} that can be used as libovsdb.Row
+func (oa ORMAPI) NewRow(tableName string, data interface{}) (map[string]interface{}, error) {
+	table, ok := oa.schema.Tables[tableName]
+	if !ok {
+		return nil, NewErrNoTable(tableName)
+	}
+	objPtrVal := reflect.ValueOf(data)
+	if objPtrVal.Type().Kind() != reflect.Ptr {
+		return nil, NewErrWrongType("ORMAPI.NewRow", "pointer to a struct", data)
+	}
+	objVal := reflect.Indirect(objPtrVal)
+	fields, err := oa.getORMFields(&table, objVal.Type())
+	if err != nil {
+		return nil, err
+	}
+	ovsRow := make(map[string]interface{}, len(table.Columns))
+	for name, column := range table.Columns {
+		fieldName, ok := fields[name]
+		if !ok {
+			// If provided struct does not have a field to hold this value, skip it
+			continue
+		}
+
+		nativeElem := objVal.FieldByName(fieldName)
+		ovsElem, err := NativeToOvs(column, nativeElem.Interface())
+		if err != nil {
+			return nil, fmt.Errorf("Table %s, Column %s: Failed to generate OvS element. %s", tableName, name, err.Error())
+		}
+		ovsRow[name] = ovsElem
+	}
+	return ovsRow, nil
+
+}
+
+// ormField contains the field information of a ORM
+// It's a map [string] string. Where the key is the column name and the value is the name of the
+// field in which the value of such column shall be stored / read from
+type ormFields map[string]string
+
+//
+func (oa ORMAPI) getORMFields(table *TableSchema, objType reflect.Type) (ormFields, error) {
+	fields := make(ormFields, objType.NumField())
+	for i := 0; i < objType.NumField(); i++ {
+		field := objType.Field(i)
+		colName := field.Tag.Get("ovs")
+		if colName == "" {
+			// Untagged fields are ignored
+			continue
+		}
+		column, err := table.GetColumn(colName)
+		if err != nil {
+			return nil, &ErrORM{
+				objType:   objType.String(),
+				field:     field.Name,
+				fieldType: field.Type.String(),
+				fieldTag:  colName,
+				reason:    "Column does not exist in schema",
+			}
+		}
+
+		// Perform schema-based type checking
+		expType := nativeType(column)
+		if expType != field.Type {
+			return nil, &ErrORM{
+				objType:   objType.String(),
+				field:     field.Name,
+				fieldType: field.Type.String(),
+				fieldTag:  colName,
+				reason:    fmt.Sprintf("Wrong type, column expects %s", expType),
+			}
+		}
+		fields[colName] = field.Name
+	}
+	return fields, nil
+}
+
+// NewCondition returns a valid condition to be used inside a Operation
+// Use the native API
+func (oa ORMAPI) NewCondition(tableName, columnName, function string, value interface{}) ([]interface{}, error) {
+	return NativeAPI{schema: oa.schema}.NewCondition(tableName, columnName, function, value)
+}
+
+// NewMutation returns a valid mutation to be used inside a Operation
+// It accepts native golang types (sets and maps)
+func (oa ORMAPI) NewMutation(tableName, columnName, mutator string, value interface{}) ([]interface{}, error) {
+	return NativeAPI{schema: oa.schema}.NewMutation(tableName, columnName, mutator, value)
+}

--- a/orm_test.go
+++ b/orm_test.go
@@ -1,0 +1,109 @@
+package libovsdb
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+type ormTestType struct {
+	AString             string            `ovs:"aString"`
+	ASet                []string          `ovs:"aSet"`
+	ASingleSet          []string          `ovs:"aSingleSet"`
+	AUUIDSet            []string          `ovs:"aUUIDSet"`
+	AUUID               string            `ovs:"aUUID"`
+	AIntSet             []int             `ovs:"aIntSet"`
+	AFloat              float64           `ovs:"aFloat"`
+	AFloatSet           []float64         `ovs:"aFloatSet"`
+	YetAnotherStringSet []string          `ovs:"aEmptySet"`
+	AEnum               string            `ovs:"aEnum"`
+	AMap                map[string]string `ovs:"aMap"`
+	NonTagged           string
+}
+
+var expected = ormTestType{
+	AString:             aString,
+	ASet:                aSet,
+	ASingleSet:          []string{aString},
+	AUUIDSet:            aUUIDSet,
+	AUUID:               aUUID0,
+	AIntSet:             aIntSet,
+	AFloat:              aFloat,
+	AFloatSet:           aFloatSet,
+	YetAnotherStringSet: []string{},
+	AEnum:               aEnum,
+	AMap:                aMap,
+	NonTagged:           "something",
+}
+
+func TestORMGetData(t *testing.T) {
+	ovsRow := getOvsTestRow()
+	/* Code under test */
+	var schema DatabaseSchema
+	if err := json.Unmarshal(testSchema, &schema); err != nil {
+		t.Error(err)
+	}
+
+	api := ORMAPI{schema: &schema}
+	orm := ormTestType{
+		NonTagged: "something",
+	}
+	err := api.GetRowData("TestTable", &ovsRow, &orm)
+	/*End code under test*/
+
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(orm, expected) {
+		t.Errorf("Failed to correctly extract ORM native value, expected %v, got %v\n",
+			expected, orm)
+	}
+}
+
+func TestORMNewRow(t *testing.T) {
+	ovsRow := getOvsTestRow()
+	/* Code under test */
+	var schema DatabaseSchema
+	if err := json.Unmarshal(testSchema, &schema); err != nil {
+		t.Error(err)
+	}
+
+	api := ORMAPI{schema: &schema}
+	orm := ormTestType{
+		AString:             aString,
+		ASet:                aSet,
+		ASingleSet:          []string{aString},
+		AUUIDSet:            aUUIDSet,
+		AUUID:               aUUID0,
+		AIntSet:             aIntSet,
+		AFloat:              aFloat,
+		AFloatSet:           aFloatSet,
+		YetAnotherStringSet: aEmptySet,
+		AEnum:               aEnum,
+		AMap:                aMap,
+		NonTagged:           "something",
+	}
+	row, err := api.NewRow("TestTable", &orm)
+	/*End code under test*/
+
+	if err != nil {
+		t.Error(err)
+	}
+	for k := range row {
+		if k == "aSingleSet" {
+			uss1, _ := NewOvsSet([]string{aString})
+			if !reflect.DeepEqual(row[k], uss1) {
+				t.Errorf("Failed to convert to ovs. Key %s", k)
+				t.Logf("value: %v\n", expectedOvs(row[k]))
+				t.Logf("expected : %v\n", uss1)
+			}
+
+		} else {
+			if !reflect.DeepEqual(expectedOvs(row[k]), ovsRow.Fields[k]) {
+				t.Errorf("Failed to convert to ovs. Key %s", k)
+				t.Logf("value: %v\n", expectedOvs(row[k]))
+				t.Logf("expected : %v\n", ovsRow.Fields[k])
+			}
+		}
+	}
+}

--- a/orm_test.go
+++ b/orm_test.go
@@ -107,6 +107,23 @@ func TestORMNewRow(t *testing.T) {
 			}
 		}
 	}
+	// Test selected cols
+	row2, err := api.NewRow("TestTable", &orm, "aSet", "aMap")
+	if err != nil {
+		t.Error(err)
+	}
+	if len(row2) != 2 {
+		t.Errorf("Expected row to be as long as the list of given columns")
+	}
+
+	// Test selected cols
+	row3, err := api.NewRow("TestTable", &orm, "nonexisting")
+	if err != nil {
+		t.Error(err)
+	}
+	if len(row3) != 0 {
+		t.Errorf("Expected row to be as long as the list of valid given columns")
+	}
 }
 
 func TestORMCondition(t *testing.T) {

--- a/schema.go
+++ b/schema.go
@@ -32,7 +32,12 @@ func (schema DatabaseSchema) GetColumn(tableName, columnName string) (*ColumnSch
 func (schema DatabaseSchema) Print(w io.Writer) {
 	fmt.Fprintf(w, "%s, (%s)\n", schema.Name, schema.Version)
 	for table, tableSchema := range schema.Tables {
-		fmt.Fprintf(w, "\t %s\n", table)
+		fmt.Fprintf(w, "\t %s", table)
+		if len(tableSchema.Indexes) > 0 {
+			fmt.Fprintf(w, "(%v)\n", tableSchema.Indexes)
+		} else {
+			fmt.Fprintf(w, "\n")
+		}
 		for column, columnSchema := range tableSchema.Columns {
 			fmt.Fprintf(w, "\t\t %s => %s\n", column, columnSchema)
 		}


### PR DESCRIPTION
Following the idea drafted in #29 and based on the work done in #30, this PR adds a ORM-like API

## Why a ORM-like API? ##
I'm opening to change the name (I'm very bad with names). The idea is to interact with libovsdb using native Objects (i.e: golang structs) instead of `map[string] interface{}`.
So, when I want to insert a Row, I can create an object, pass it to the library and it will take care of inserting it in the right table and perform the right native-to-ovs type conversions.

## How does it work? ##
Similarly to  #30, it uses the schema bindings to figure out the exact conversion needed for each column. But, how do we tell the library which field of my struct goes into what column? well, borrowing the idea from @vtolstov, I propose to use a struct tag called "ovs". 

The orm API then uses `reflect` to inspect the type of structure given and populate the fields accordingly.

### Example ###
This is an example of how you would use this API
```
type MyRow struct {
	Name      string            `ovs:"name"`
	SomeRef   []string          `ovs:"someRef"`
	ExtraConf map[string]string `ovs:"extra_config"`
}

# Parse incoming data from OVSDB (stored in 'rowData')
var aRow MyRow
ormAPI.GetRowData(TableName, rowData, &myRow)
fmt.Printf("Received a row named %s: %+v", aRow.Name, aRow)

# Format data to send to OVSDB
bRow := MyRow {
 Name: "foo",
 SomeRef: []string{"2f77b348-9768-4866-b761-89d5177ecda0"},
 ExtraConf: map[string] string {"foo": "bar"},
}
ovsRow, _ := ormAPI.NewRow(TableName, bRow)

```

##  Related work ##
Based on this API, I have created a PR in go-ovn that exposes a ORM API: 
Also, an example of a fully-blown go-ovn object-based API access that has been developed using this PR can be seen here: https://github.com/amorenoz/ovnmodel


