### PR TITLE
Extend OVSDB Set encoding/decoding to support single values

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -2,27 +2,205 @@ package libovsdb
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// empty Set test
-func TestEmptySet(t *testing.T) {
-	emptySet, err := NewOvsSet([]string{})
-	assert.Nil(t, err)
-	jsonStr, err := json.Marshal(emptySet)
-	assert.Nil(t, err)
-	expected := "[\"set\",[]]"
-	assert.JSONEqf(t, expected, string(jsonStr), "they should be equal\n")
+type marshalSetTestTuple struct {
+	objInput           interface{}
+	jsonExpectedOutput string
 }
 
-// empty Map test
-func TestEmptyMap(t *testing.T) {
-	emptyMap, err := NewOvsMap(map[string]string{})
-	assert.Nil(t, err)
-	jsonStr, err := json.Marshal(emptyMap)
-	assert.Nil(t, err)
-	expected := "[\"map\",[]]"
-	assert.JSONEqf(t, expected, string(jsonStr), "they should be equal\n")
+type marshalMapsTestTuple struct {
+	objInput           map[string]string
+	jsonExpectedOutput string
+}
+
+var validUuidStr0 = `00000000-0000-0000-0000-000000000000`
+var validUuidStr1 = `11111111-1111-1111-1111-111111111111`
+var validUuid0 = UUID{GoUUID: validUuidStr0}
+var validUuid1 = UUID{GoUUID: validUuidStr1}
+
+var setTestList = []marshalSetTestTuple{
+	{
+		objInput:           []string{},
+		jsonExpectedOutput: `["set",[]]`,
+	},
+	{
+		objInput:           `aa`,
+		jsonExpectedOutput: `"aa"`,
+	},
+	{
+		objInput:           false,
+		jsonExpectedOutput: `false`,
+	},
+	{
+		objInput:           10,
+		jsonExpectedOutput: `10`,
+	},
+	{
+		objInput:           10.2,
+		jsonExpectedOutput: `10.2`,
+	},
+	{
+		objInput:           []string{`aa`},
+		jsonExpectedOutput: `"aa"`,
+	},
+	{
+		objInput:           [1]string{`aa`},
+		jsonExpectedOutput: `"aa"`,
+	},
+	{
+		objInput:           []string{`aa`, `bb`},
+		jsonExpectedOutput: `["set",["aa","bb"]]`,
+	},
+	{
+		objInput:           [2]string{`aa`, `bb`},
+		jsonExpectedOutput: `["set",["aa","bb"]]`,
+	},
+	{
+		objInput:           []int{10, 15},
+		jsonExpectedOutput: `["set",[10,15]]`,
+	},
+	{
+		objInput:           []uint16{10, 15},
+		jsonExpectedOutput: `["set",[10,15]]`,
+	},
+	{
+		objInput:           []float32{10.2, 15.4},
+		jsonExpectedOutput: `["set",[10.2,15.4]]`,
+	},
+	{
+		objInput:           []float64{10.2, 15.4},
+		jsonExpectedOutput: `["set",[10.2,15.4]]`,
+	},
+	{
+		objInput:           []UUID{},
+		jsonExpectedOutput: `["set",[]]`,
+	},
+	{
+		objInput:           UUID{GoUUID: `aa`},
+		jsonExpectedOutput: `["named-uuid","aa"]`,
+	},
+	{
+		objInput:           []UUID{UUID{GoUUID: `aa`}},
+		jsonExpectedOutput: `["named-uuid","aa"]`,
+	},
+	{
+		objInput:           []UUID{UUID{GoUUID: `aa`}, UUID{GoUUID: `bb`}},
+		jsonExpectedOutput: `["set",[["named-uuid","aa"],["named-uuid","bb"]]]`,
+	},
+	{
+		objInput:           validUuid0,
+		jsonExpectedOutput: fmt.Sprintf(`["uuid","%v"]`, validUuidStr0),
+	},
+	{
+		objInput:           []UUID{validUuid0},
+		jsonExpectedOutput: fmt.Sprintf(`["uuid","%v"]`, validUuidStr0),
+	},
+	{
+		objInput:           []UUID{validUuid0, validUuid1},
+		jsonExpectedOutput: fmt.Sprintf(`["set",[["uuid","%v"],["uuid","%v"]]]`, validUuidStr0, validUuidStr1),
+	},
+}
+
+var mapTestList = []marshalMapsTestTuple{
+	{
+		objInput:           map[string]string{},
+		jsonExpectedOutput: `["map",[]]`,
+	},
+
+	{
+		objInput:           map[string]string{`v0`: `k0`},
+		jsonExpectedOutput: `["map",[["v0","k0"]]]`,
+	},
+
+	{
+		objInput:           map[string]string{`v0`: `k0`, `v1`: `k1`},
+		jsonExpectedOutput: `["map",[["v0","k0"],["v1","k1"]]]`,
+	},
+}
+
+// Json array is not order sensitive, but Golang set is, so we have to compare teh sets independently to the order of
+// its elements
+func setsAreEqual(t *testing.T, set1 *OvsSet, set2 *OvsSet) {
+	res1 := map[interface{}]bool{}
+	for _, elem := range set1.GoSet {
+		switch elem.(type) {
+		case UUID:
+			uuid := elem.(UUID)
+			res1[uuid.GoUUID] = true
+		default:
+			s := fmt.Sprintf("%v", elem)
+			res1[s] = true
+		}
+	}
+
+	res2 := map[interface{}]bool{}
+	for _, elem := range set2.GoSet {
+		switch elem.(type) {
+		case UUID:
+			uuid := elem.(UUID)
+			res2[uuid.GoUUID] = true
+		default:
+			s := fmt.Sprintf("%v", elem)
+			res2[s] = true
+		}
+	}
+	assert.Equal(t, res1, res2, "they should be equal\n")
+}
+
+func TestMarshalSet(t *testing.T) {
+
+	for _, e := range setTestList {
+		set, err := NewOvsSet(e.objInput)
+		assert.Nil(t, err)
+		jsonStr, err := json.Marshal(set)
+		assert.Nil(t, err)
+		assert.JSONEqf(t, e.jsonExpectedOutput, string(jsonStr), "they should be equal\n")
+	}
+
+}
+
+func TestMarshalMap(t *testing.T) {
+
+	for _, e := range mapTestList {
+		m, err := NewOvsMap(e.objInput)
+		assert.Nil(t, err)
+		jsonStr, err := json.Marshal(m)
+		assert.Nil(t, err)
+		assert.JSONEqf(t, e.jsonExpectedOutput, string(jsonStr), "they should be equal\n")
+	}
+
+}
+
+func TestUnmarshalSet(t *testing.T) {
+
+	for _, e := range setTestList {
+		set, err := NewOvsSet(e.objInput)
+		assert.Nil(t, err)
+		jsonStr, err := json.Marshal(set)
+		assert.Nil(t, err)
+		var res OvsSet
+		err = json.Unmarshal(jsonStr, &res)
+		assert.Nil(t, err)
+		setsAreEqual(t, set, &res)
+	}
+
+}
+
+func TestUnmarshalMap(t *testing.T) {
+
+	for _, e := range mapTestList {
+		m, err := NewOvsMap(e.objInput)
+		assert.Nil(t, err)
+		jsonStr, err := json.Marshal(m)
+		assert.Nil(t, err)
+		var res OvsMap
+		err = json.Unmarshal(jsonStr, &res)
+		assert.Nil(t, err)
+		assert.Equal(t, *m, res, "they should be equal\n")
+	}
 }

--- a/notation.go
+++ b/notation.go
@@ -126,7 +126,7 @@ func ovsSliceToGoNotation(val interface{}) (interface{}, error) {
 		}
 
 		switch sl[0] {
-		case "uuid":
+		case "uuid", "named-uuid":
 			var uuid UUID
 			err = json.Unmarshal(bsliced, &uuid)
 			return uuid, err

--- a/notation_test.go
+++ b/notation_test.go
@@ -75,9 +75,9 @@ func TestValidateOvsSet(t *testing.T) {
 	}
 	// Negative condition test
 	integer := 5
-	oSet, err = NewOvsSet(integer)
+	oSet, err = NewOvsSet(&integer)
 	if err == nil {
-		t.Error("OvsSet must fail for anything other than Slices")
+		t.Error("OvsSet must fail for anything other than Slices and atomic types")
 		t.Error("Expected: ", expected, "Got", string(data))
 	}
 }

--- a/set.go
+++ b/set.go
@@ -17,23 +17,34 @@ type OvsSet struct {
 	GoSet []interface{}
 }
 
-// NewOvsSet creates a new OVSDB style set from a Go slice
-func NewOvsSet(goSlice interface{}) (*OvsSet, error) {
-	v := reflect.ValueOf(goSlice)
-	if v.Kind() != reflect.Slice {
-		return nil, errors.New("OvsSet supports only Go Slice types")
-	}
-
+// NewOvsSet creates a new OVSDB style set from a Go interface (object)
+func NewOvsSet(obj interface{}) (*OvsSet, error) {
+	v := reflect.ValueOf(obj)
 	var ovsSet []interface{}
-	for i := 0; i < v.Len(); i++ {
-		ovsSet = append(ovsSet, v.Index(i).Interface())
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			ovsSet = append(ovsSet, v.Index(i).Interface())
+		}
+	case reflect.String,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.Bool:
+		ovsSet = append(ovsSet, v.Interface())
+	case reflect.ValueOf(UUID{}).Kind():
+		ovsSet = append(ovsSet, v.Interface())
+	default:
+		return nil, errors.New("OvsSet supports only Go Slice/string/numbers/uuid types")
 	}
 	return &OvsSet{ovsSet}, nil
 }
 
-// MarshalJSON wil marshal an OVSDB style set in to a JSON byte array
+// MarshalJSON wil marshal an OVSDB style Set in to a JSON byte array
 func (o OvsSet) MarshalJSON() ([]byte, error) {
-	if len(o.GoSet) > 0 {
+	switch l := len(o.GoSet); {
+	case l == 1:
+		return json.Marshal(o.GoSet[0])
+	case l > 0:
 		var oSet []interface{}
 		oSet = append(oSet, "set")
 		oSet = append(oSet, o.GoSet)
@@ -42,17 +53,42 @@ func (o OvsSet) MarshalJSON() ([]byte, error) {
 	return []byte("[\"set\",[]]"), nil
 }
 
-// UnmarshalJSON will unmarshal a JSON byte array to an OVSDB style set
+// UnmarshalJSON will unmarshal a JSON byte array to an OVSDB style Set
 func (o *OvsSet) UnmarshalJSON(b []byte) (err error) {
-	var oSet []interface{}
-	if err = json.Unmarshal(b, &oSet); err == nil && len(oSet) > 1 {
+	addToSet := func(o *OvsSet, v interface{}) error {
+		goVal, err := ovsSliceToGoNotation(v)
+		if err == nil {
+			o.GoSet = append(o.GoSet, goVal)
+		}
+		return err
+	}
+
+	var inter interface{}
+	if err = json.Unmarshal(b, &inter); err != nil {
+		return err
+	}
+	switch inter.(type) {
+	case []interface{}:
+		var oSet []interface{}
+		oSet = inter.([]interface{})
+		// it's a single uuid object
+		if len(oSet) == 2 && (oSet[0] == "uuid" || oSet[0] == "named-uuid") {
+			return addToSet(o, UUID{GoUUID: oSet[1].(string)})
+		}
+		if oSet[0] != "set" {
+			// it is a slice, but is not a set
+			return &json.UnmarshalTypeError{Value: reflect.ValueOf(inter).String(), Type: reflect.TypeOf(*o)}
+		}
 		innerSet := oSet[1].([]interface{})
 		for _, val := range innerSet {
-			goVal, err := ovsSliceToGoNotation(val)
-			if err == nil {
-				o.GoSet = append(o.GoSet, goVal)
+			err := addToSet(o, val)
+			if err != nil {
+				return err
 			}
 		}
+		return err
+	default:
+		// it is a single object
+		return addToSet(o, inter)
 	}
-	return err
 }


### PR DESCRIPTION
This PR extends OVSDB's marshaling and unmarshaling functions to support single values according to OVSDB spec. 
For example, if the set contains a single element, its JSON string will be this atomic element, instead of the Set. It's true to the opposite direction as well, if a JSON string contains a single element only, we can parse it into `OvsSet`. 
 
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>