### PR TITLE
Implement a Cache For Monitor Updates

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,192 @@
+package libovsdb
+
+import (
+	"reflect"
+	"sync"
+)
+
+// RowCache is a collections of Rows hashed by UUID
+type RowCache struct {
+	cache map[string]Row
+	mutex sync.Mutex
+}
+
+// Row returns one row the from the cache by uuid
+func (r *RowCache) Row(uuid string) *Row {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if row, ok := r.cache[uuid]; ok {
+		return &row
+	}
+	return nil
+}
+
+// Rows returns a list of row UUIDs as strings
+func (r *RowCache) Rows() []string {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	var result []string
+	for k := range r.cache {
+		result = append(result, k)
+	}
+	return result
+}
+
+func newRowCache() *RowCache {
+	return &RowCache{
+		cache: make(map[string]Row),
+		mutex: sync.Mutex{},
+	}
+}
+
+// EventHandler can handle events that happen to cache rowects
+type EventHandler interface {
+	OnAdd(table string, row Row)
+	OnUpdate(table string, old Row, new Row)
+	OnDelete(table string, row Row)
+}
+
+// EventHandlerFuncs is a wrapper for the EventHandler interface
+// It allows a caller to only implement the functions they need
+type EventHandlerFuncs struct {
+	AddFunc    func(table string, row Row)
+	UpdateFunc func(table string, old Row, new Row)
+	DeleteFunc func(table string, row Row)
+}
+
+// OnAdd calls AddFunc if it is not nil
+func (e *EventHandlerFuncs) OnAdd(table string, row Row) {
+	if e.AddFunc != nil {
+		e.AddFunc(table, row)
+	}
+}
+
+// OnUpdate calls UpdateFunc if it is not nil
+func (e *EventHandlerFuncs) OnUpdate(table string, old, new Row) {
+	if e.UpdateFunc != nil {
+		e.UpdateFunc(table, old, new)
+	}
+}
+
+// OnDelete calls DeleteFunc if it is not nil
+func (e *EventHandlerFuncs) OnDelete(table string, row Row) {
+	if e.DeleteFunc != nil {
+		e.DeleteFunc(table, row)
+	}
+}
+
+// TableCache is a collection of TableCache hashed by database name
+type TableCache struct {
+	cache         map[string]*RowCache
+	cacheMutex    sync.Mutex
+	handlers      []EventHandler
+	handlersMutex sync.Mutex
+}
+
+func newTableCache() *TableCache {
+	return &TableCache{
+		cache:         make(map[string]*RowCache),
+		cacheMutex:    sync.Mutex{},
+		handlersMutex: sync.Mutex{},
+	}
+}
+
+// Table returns the from the cache
+func (t *TableCache) Table(name string) *RowCache {
+	t.cacheMutex.Lock()
+	defer t.cacheMutex.Unlock()
+	if table, ok := t.cache[name]; ok {
+		return table
+	}
+	return nil
+}
+
+// Tables returns a list of tables
+func (t *TableCache) Tables() []string {
+	t.cacheMutex.Lock()
+	defer t.cacheMutex.Unlock()
+	var result []string
+	for k := range t.cache {
+		result = append(result, k)
+	}
+	return result
+}
+
+// Update implements the update method of the NotificationHandler interface
+// this populates the cache with new updates
+func (t *TableCache) Update(context interface{}, tableUpdates TableUpdates) {
+	if len(tableUpdates.Updates) == 0 {
+		return
+	}
+	go t.populate(tableUpdates)
+}
+
+// Locked implements the locked method of the NotificationHandler interface
+func (t *TableCache) Locked([]interface{}) {
+}
+
+// Stolen implements the stolen method of the NotificationHandler interface
+func (t *TableCache) Stolen([]interface{}) {
+}
+
+// Echo implements the echo method of the NotificationHandler interface
+func (t *TableCache) Echo([]interface{}) {
+}
+
+// Disconnected implements the disconnected method of the NotificationHandler interface
+func (t *TableCache) Disconnected() {
+}
+
+func (t *TableCache) populate(tableUpdates TableUpdates) {
+	t.cacheMutex.Lock()
+	defer t.cacheMutex.Unlock()
+	for table, updates := range tableUpdates.Updates {
+		var tCache *RowCache
+		var ok bool
+		if tCache, ok = t.cache[table]; !ok {
+			t.cache[table] = newRowCache()
+			tCache = t.cache[table]
+		}
+		tCache.mutex.Lock()
+		for uuid, row := range updates.Rows {
+			if !reflect.DeepEqual(row.New, Row{}) {
+				if existing, ok := tCache.cache[uuid]; ok {
+					if !reflect.DeepEqual(row.New, existing) {
+						tCache.cache[uuid] = row.New
+						t.handlersMutex.Lock()
+						for _, handler := range t.handlers {
+							go handler.OnUpdate(table, row.Old, row.New)
+						}
+						t.handlersMutex.Unlock()
+					}
+					// no diff
+					continue
+				}
+				tCache.cache[uuid] = row.New
+				t.handlersMutex.Lock()
+				for _, handler := range t.handlers {
+					go handler.OnAdd(table, row.New)
+				}
+				t.handlersMutex.Unlock()
+				continue
+			} else {
+				// delete from cache
+				delete(tCache.cache, uuid)
+				t.handlersMutex.Lock()
+				for _, handler := range t.handlers {
+					go handler.OnDelete(table, row.Old)
+				}
+				t.handlersMutex.Unlock()
+				continue
+			}
+		}
+		tCache.mutex.Unlock()
+	}
+}
+
+// AddEventHandler registers the supplied EventHandler to recieve cache events
+func (t *TableCache) AddEventHandler(handler EventHandler) {
+	t.handlersMutex.Lock()
+	defer t.handlersMutex.Unlock()
+	t.handlers = append(t.handlers, handler)
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,345 @@
+package libovsdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRowCache_Row(t *testing.T) {
+	type fields struct {
+		cache map[string]Row
+	}
+	type args struct {
+		uuid string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *Row
+	}{
+		{
+			"returns a row that exists",
+			fields{cache: map[string]Row{"test": {}}},
+			args{uuid: "test"},
+			&Row{},
+		},
+		{
+			"returns a nil for a row that does not exist",
+			fields{cache: map[string]Row{"test": {}}},
+			args{uuid: "foo"},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RowCache{
+				cache: tt.fields.cache,
+			}
+			got := r.Row(tt.args.uuid)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRowCache_Rows(t *testing.T) {
+	type fields struct {
+		cache map[string]Row
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			"returns a rows that exist",
+			fields{cache: map[string]Row{"test1": {}, "test2": {}, "test3": {}}},
+			[]string{"test1", "test2", "test3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RowCache{
+				cache: tt.fields.cache,
+			}
+			got := r.Rows()
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestEventHandlerFuncs_OnAdd(t *testing.T) {
+	calls := 0
+	type fields struct {
+		AddFunc    func(table string, row Row)
+		UpdateFunc func(table string, old Row, new Row)
+		DeleteFunc func(table string, row Row)
+	}
+	type args struct {
+		table string
+		row   Row
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			"doesn't call nil function",
+			fields{nil, nil, nil},
+			args{"testTable", Row{}},
+		},
+		{
+			"calls onadd function",
+			fields{func(string, Row) {
+				calls++
+			}, nil, nil},
+			args{"testTable", Row{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EventHandlerFuncs{
+				AddFunc:    tt.fields.AddFunc,
+				UpdateFunc: tt.fields.UpdateFunc,
+				DeleteFunc: tt.fields.DeleteFunc,
+			}
+			e.OnAdd(tt.args.table, tt.args.row)
+			if e.AddFunc != nil {
+				assert.Equal(t, 1, calls)
+			}
+		})
+	}
+}
+
+func TestEventHandlerFuncs_OnUpdate(t *testing.T) {
+	calls := 0
+	type fields struct {
+		AddFunc    func(table string, row Row)
+		UpdateFunc func(table string, old Row, new Row)
+		DeleteFunc func(table string, row Row)
+	}
+	type args struct {
+		table string
+		old   Row
+		new   Row
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			"doesn't call nil function",
+			fields{nil, nil, nil},
+			args{"testTable", Row{}, Row{}},
+		},
+		{
+			"calls onupdate function",
+			fields{nil, func(string, Row, Row) {
+				calls++
+			}, nil},
+			args{"testTable", Row{}, Row{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EventHandlerFuncs{
+				AddFunc:    tt.fields.AddFunc,
+				UpdateFunc: tt.fields.UpdateFunc,
+				DeleteFunc: tt.fields.DeleteFunc,
+			}
+			e.OnUpdate(tt.args.table, tt.args.old, tt.args.new)
+			if e.UpdateFunc != nil {
+				assert.Equal(t, 1, calls)
+			}
+		})
+	}
+}
+
+func TestEventHandlerFuncs_OnDelete(t *testing.T) {
+	calls := 0
+	type fields struct {
+		AddFunc    func(table string, row Row)
+		UpdateFunc func(table string, old Row, new Row)
+		DeleteFunc func(table string, row Row)
+	}
+	type args struct {
+		table string
+		row   Row
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			"doesn't call nil function",
+			fields{nil, nil, nil},
+			args{"testTable", Row{}},
+		},
+		{
+			"calls ondelete function",
+			fields{nil, nil, func(string, Row) {
+				calls++
+			}},
+			args{"testTable", Row{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EventHandlerFuncs{
+				AddFunc:    tt.fields.AddFunc,
+				UpdateFunc: tt.fields.UpdateFunc,
+				DeleteFunc: tt.fields.DeleteFunc,
+			}
+			e.OnDelete(tt.args.table, tt.args.row)
+			if e.DeleteFunc != nil {
+				assert.Equal(t, 1, calls)
+			}
+		})
+	}
+}
+
+func TestTableCache_Table(t *testing.T) {
+	type fields struct {
+		cache map[string]*RowCache
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *RowCache
+	}{
+		{
+			"returns nil for an empty table",
+			fields{
+				cache: map[string]*RowCache{"bar": newRowCache()},
+			},
+			args{
+				"foo",
+			},
+			nil,
+		},
+		{
+			"returns nil for an empty table",
+			fields{
+				cache: map[string]*RowCache{"bar": newRowCache()},
+			},
+			args{
+				"bar",
+			},
+			newRowCache(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &TableCache{
+				cache: tt.fields.cache,
+			}
+			got := tr.Table(tt.args.name)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTableCache_Tables(t *testing.T) {
+	type fields struct {
+		cache map[string]*RowCache
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			"returns a table that exists",
+			fields{cache: map[string]*RowCache{"test1": newRowCache(), "test2": newRowCache(), "test3": newRowCache()}},
+			[]string{"test1", "test2", "test3"},
+		},
+		{
+			"returns an empty slice if no tables exist",
+			fields{cache: map[string]*RowCache{}},
+			[]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &TableCache{
+				cache: tt.fields.cache,
+			}
+			got := tr.Tables()
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestTableCache_populate(t *testing.T) {
+	t.Log("Create")
+	tc := newTableCache()
+	testRow := Row{Fields: map[string]interface{}{"_uuid": "test", "foo": "bar"}}
+	updates := TableUpdates{
+		Updates: map[string]TableUpdate{
+			"Open_vSwitch": {
+				Rows: map[string]RowUpdate{
+					"test": {
+						Old: Row{},
+						New: testRow,
+					},
+				},
+			},
+		},
+	}
+	tc.populate(updates)
+
+	got := tc.cache["Open_vSwitch"].cache["test"]
+	assert.Equal(t, testRow, got)
+
+	t.Log("Update")
+	updatedRow := Row{Fields: map[string]interface{}{"_uuid": "test", "foo": "quux"}}
+	updates = TableUpdates{
+		Updates: map[string]TableUpdate{
+			"Open_vSwitch": {
+				Rows: map[string]RowUpdate{
+					"test": {
+						Old: testRow,
+						New: updatedRow,
+					},
+				},
+			},
+		},
+	}
+	tc.populate(updates)
+
+	got = tc.cache["Open_vSwitch"].cache["test"]
+	assert.Equal(t, updatedRow, got)
+
+	t.Log("Delete")
+	updates = TableUpdates{
+		Updates: map[string]TableUpdate{
+			"Open_vSwitch": {
+				Rows: map[string]RowUpdate{
+					"test": {
+						Old: updatedRow,
+						New: Row{},
+					},
+				},
+			},
+		},
+	}
+
+	tc.populate(updates)
+
+	_, ok := tc.cache["Open_vSwitch"].cache["test"]
+	assert.False(t, ok)
+}
+
+func TestTableCache_AddEventHandler(t *testing.T) {
+	tc := newTableCache()
+	tc.AddEventHandler(&EventHandlerFuncs{nil, nil, nil})
+	assert.Equal(t, 1, len(tc.handlers))
+}

--- a/client.go
+++ b/client.go
@@ -178,7 +178,7 @@ type NotificationHandler interface {
 	// RFC 7047 section 4.1.11 Echo Notification
 	Echo([]interface{})
 
-	Disconnected(*OvsdbClient)
+	Disconnected()
 }
 
 // RFC 7047 : Section 4.1.6 : Echo
@@ -345,7 +345,7 @@ func clearConnection(c *rpc2.Client) {
 	if _, ok := connections[c]; ok {
 		for _, handler := range connections[c].handlers {
 			if handler != nil {
-				handler.Disconnected(connections[c])
+				handler.Disconnected()
 			}
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -260,17 +260,14 @@ func (ovs OvsdbClient) ListDbs() ([]string, error) {
 
 // Transact performs the provided Operation's on the database
 // RFC 7047 : transact
-func (ovs OvsdbClient) Transact(database string, operation ...Operation) ([]OperationResult, error) {
+func (ovs OvsdbClient) Transact(operation ...Operation) ([]OperationResult, error) {
 	var reply []OperationResult
-	if database != ovs.Schema.Name {
-		return nil, fmt.Errorf("requested database %s doesn't match available schema %s", database, ovs.Schema.Name)
-	}
 
 	if ok := ovs.Schema.validateOperations(operation...); !ok {
 		return nil, errors.New("Validation failed for the operation")
 	}
 
-	args := NewTransactArgs(database, operation...)
+	args := NewTransactArgs(ovs.Schema.Name, operation...)
 	err := ovs.rpcClient.Call("transact", args, &reply)
 	if err != nil {
 		return nil, err
@@ -279,11 +276,7 @@ func (ovs OvsdbClient) Transact(database string, operation ...Operation) ([]Oper
 }
 
 // MonitorAll is a convenience method to monitor every table/column
-func (ovs OvsdbClient) MonitorAll(database string, jsonContext interface{}) (*TableUpdates, error) {
-	if database != ovs.Schema.Name {
-		return nil, fmt.Errorf("requested database %s doesn't match available schema %s", database, ovs.Schema.Name)
-	}
-
+func (ovs OvsdbClient) MonitorAll(jsonContext interface{}) (*TableUpdates, error) {
 	requests := make(map[string]MonitorRequest)
 	for table, tableSchema := range ovs.Schema.Tables {
 		var columns []string
@@ -299,7 +292,7 @@ func (ovs OvsdbClient) MonitorAll(database string, jsonContext interface{}) (*Ta
 				Modify:  true,
 			}}
 	}
-	return ovs.Monitor(database, jsonContext, requests)
+	return ovs.Monitor(jsonContext, requests)
 }
 
 // MonitorCancel will request cancel a previously issued monitor request
@@ -321,10 +314,10 @@ func (ovs OvsdbClient) MonitorCancel(jsonContext interface{}) error {
 
 // Monitor will provide updates for a given table/column
 // RFC 7047 : monitor
-func (ovs OvsdbClient) Monitor(database string, jsonContext interface{}, requests map[string]MonitorRequest) (*TableUpdates, error) {
+func (ovs OvsdbClient) Monitor(jsonContext interface{}, requests map[string]MonitorRequest) (*TableUpdates, error) {
 	var reply TableUpdates
 
-	args := NewMonitorArgs(database, jsonContext, requests)
+	args := NewMonitorArgs(ovs.Schema.Name, jsonContext, requests)
 
 	// This totally sucks. Refer to golang JSON issue #6213
 	var response map[string]map[string]RowUpdate

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -18,10 +18,10 @@ type marshalMapsTestTuple struct {
 	jsonExpectedOutput string
 }
 
-var validUuidStr0 = `00000000-0000-0000-0000-000000000000`
-var validUuidStr1 = `11111111-1111-1111-1111-111111111111`
-var validUuid0 = UUID{GoUUID: validUuidStr0}
-var validUuid1 = UUID{GoUUID: validUuidStr1}
+var validUUIDStr0 = `00000000-0000-0000-0000-000000000000`
+var validUUIDStr1 = `11111111-1111-1111-1111-111111111111`
+var validUUID0 = UUID{GoUUID: validUUIDStr0}
+var validUUID1 = UUID{GoUUID: validUUIDStr1}
 
 var setTestList = []marshalSetTestTuple{
 	{
@@ -85,24 +85,24 @@ var setTestList = []marshalSetTestTuple{
 		jsonExpectedOutput: `["named-uuid","aa"]`,
 	},
 	{
-		objInput:           []UUID{UUID{GoUUID: `aa`}},
+		objInput:           []UUID{{GoUUID: `aa`}},
 		jsonExpectedOutput: `["named-uuid","aa"]`,
 	},
 	{
-		objInput:           []UUID{UUID{GoUUID: `aa`}, UUID{GoUUID: `bb`}},
+		objInput:           []UUID{{GoUUID: `aa`}, {GoUUID: `bb`}},
 		jsonExpectedOutput: `["set",[["named-uuid","aa"],["named-uuid","bb"]]]`,
 	},
 	{
-		objInput:           validUuid0,
-		jsonExpectedOutput: fmt.Sprintf(`["uuid","%v"]`, validUuidStr0),
+		objInput:           validUUID0,
+		jsonExpectedOutput: fmt.Sprintf(`["uuid","%v"]`, validUUIDStr0),
 	},
 	{
-		objInput:           []UUID{validUuid0},
-		jsonExpectedOutput: fmt.Sprintf(`["uuid","%v"]`, validUuidStr0),
+		objInput:           []UUID{validUUID0},
+		jsonExpectedOutput: fmt.Sprintf(`["uuid","%v"]`, validUUIDStr0),
 	},
 	{
-		objInput:           []UUID{validUuid0, validUuid1},
-		jsonExpectedOutput: fmt.Sprintf(`["set",[["uuid","%v"],["uuid","%v"]]]`, validUuidStr0, validUuidStr1),
+		objInput:           []UUID{validUUID0, validUUID1},
+		jsonExpectedOutput: fmt.Sprintf(`["set",[["uuid","%v"],["uuid","%v"]]]`, validUUIDStr0, validUUIDStr1),
 	},
 }
 

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -28,7 +28,7 @@ func play(ovs *libovsdb.OvsdbClient) {
 			for table, tableUpdate := range currUpdate.Updates {
 				if table == bridgeTable {
 					for uuid, row := range tableUpdate.Rows {
-						rowData, err := ovs.Apis[ovsDb].GetRowData(bridgeTable, &row.New)
+						rowData, err := ovs.API.GetRowData(bridgeTable, &row.New)
 						if err != nil {
 							fmt.Println("ERROR getting Bridge Data", err)
 						}
@@ -49,14 +49,13 @@ func play(ovs *libovsdb.OvsdbClient) {
 }
 
 func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
-	api := ovs.Apis[ovsDb]
 	namedUUID := "gopher"
 	// bridge row to insert
 	bridge := make(map[string]interface{})
 	bridge["name"] = bridgeName
 	bridge["external_ids"] = map[string]string{"purpose": "fun"}
 
-	brow, err := api.NewRow(bridgeTable, bridge)
+	brow, err := ovs.API.NewRow(bridgeTable, bridge)
 	if err != nil {
 		fmt.Printf("Row Error: %s", err.Error())
 		os.Exit(1)
@@ -71,12 +70,12 @@ func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
 	}
 
 	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
-	mutation, err := api.NewMutation(ovsTable, "bridges", "insert", []string{namedUUID})
+	mutation, err := ovs.API.NewMutation(ovsTable, "bridges", "insert", []string{namedUUID})
 	if err != nil {
 		fmt.Printf("Mutation Error: %s", err.Error())
 		os.Exit(1)
 	}
-	condition, err := api.NewCondition(ovsTable, "_uuid", "==", getRootUUID())
+	condition, err := ovs.API.NewCondition(ovsTable, "_uuid", "==", getRootUUID())
 	if err != nil {
 		fmt.Printf("Condition Error: %s", err.Error())
 		os.Exit(1)
@@ -150,7 +149,7 @@ func main() {
 	cache = make(map[string]map[string]libovsdb.Row)
 
 	// By default libovsdb connects to 127.0.0.0:6400.
-	ovs, err := libovsdb.Connect("tcp:", nil)
+	ovs, err := libovsdb.Connect("tcp:", "Open_vSwitch", nil)
 
 	// If you prefer to connect to OVS in a specific location :
 	// ovs, err := libovsdb.Connect("tcp:192.168.56.101:6640", nil)

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -90,7 +90,7 @@ func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
 	}
 
 	operations := []libovsdb.Operation{insertOp, mutateOp}
-	reply, _ := ovs.Transact(ovsDb, operations...)
+	reply, _ := ovs.Transact(operations...)
 
 	if len(reply) < len(operations) {
 		fmt.Println("Number of Replies should be atleast equal to number of Operations")
@@ -161,7 +161,7 @@ func main() {
 	var notifier myNotifier
 	ovs.Register(notifier)
 
-	initial, _ := ovs.MonitorAll(ovsDb, "")
+	initial, _ := ovs.MonitorAll("")
 	populateCache(*initial)
 
 	fmt.Println(`Silly game of stopping this app when a Bridge with name "stop" is monitored !`)

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -182,5 +182,5 @@ func (n myNotifier) Stolen([]interface{}) {
 }
 func (n myNotifier) Echo([]interface{}) {
 }
-func (n myNotifier) Disconnected(client *libovsdb.OvsdbClient) {
+func (n myNotifier) Disconnected() {
 }

--- a/example/play_with_ovs/play_with_ovs.go
+++ b/example/play_with_ovs/play_with_ovs.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"os"
+	"log"
 	"reflect"
 
 	"github.com/ebay/libovsdb"
@@ -57,9 +57,7 @@ func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
 
 	brow, err := ovs.API.NewRow(bridgeTable, bridge)
 	if err != nil {
-		fmt.Printf("Row Error: %s", err.Error())
-		os.Exit(1)
-
+		log.Fatalf("Row Error: %s", err.Error())
 	}
 	// simple insert operation
 	insertOp := libovsdb.Operation{
@@ -72,25 +70,26 @@ func createBridge(ovs *libovsdb.OvsdbClient, bridgeName string) {
 	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
 	mutation, err := ovs.API.NewMutation(ovsTable, "bridges", "insert", []string{namedUUID})
 	if err != nil {
-		fmt.Printf("Mutation Error: %s", err.Error())
-		os.Exit(1)
+		log.Fatalf("Mutation Error: %s", err.Error())
 	}
 	condition, err := ovs.API.NewCondition(ovsTable, "_uuid", "==", getRootUUID())
 	if err != nil {
-		fmt.Printf("Condition Error: %s", err.Error())
-		os.Exit(1)
+		log.Fatalf("Condition Error: %s", err.Error())
 	}
 
 	// simple mutate operation
 	mutateOp := libovsdb.Operation{
 		Op:        "mutate",
-		Table:     "ovsTable",
+		Table:     ovsTable,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
 
 	operations := []libovsdb.Operation{insertOp, mutateOp}
-	reply, _ := ovs.Transact(operations...)
+	reply, err := ovs.Transact(operations...)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if len(reply) < len(operations) {
 		fmt.Println("Number of Replies should be atleast equal to number of Operations")
@@ -155,8 +154,7 @@ func main() {
 	// ovs, err := libovsdb.Connect("tcp:192.168.56.101:6640", nil)
 
 	if err != nil {
-		fmt.Println("Unable to Connect ", err)
-		os.Exit(1)
+		log.Fatal("Unable to Connect ", err)
 	}
 	var notifier myNotifier
 	ovs.Register(notifier)

--- a/example/stress/stress.go
+++ b/example/stress/stress.go
@@ -34,7 +34,7 @@ func list() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	final, err := ovs.MonitorAll("Open_vSwitch", "")
+	final, err := ovs.MonitorAll("")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func run() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	initial, _ := ovs.MonitorAll("Open_vSwitch", "")
+	initial, _ := ovs.MonitorAll("")
 	if *verbose {
 		fmt.Printf("initial : %v\n\n", initial)
 	}
@@ -79,7 +79,7 @@ OUTER:
 }
 
 func transact(ovs *libovsdb.OvsdbClient, operations []libovsdb.Operation) (ok bool, uuid string) {
-	reply, _ := ovs.Transact("Open_vSwitch", operations...)
+	reply, _ := ovs.Transact(operations...)
 
 	if len(reply) < len(operations) {
 		fmt.Println("Number of Replies should be atleast equal to number of Operations")

--- a/example/stress/stress.go
+++ b/example/stress/stress.go
@@ -30,7 +30,7 @@ var (
 )
 
 func list() {
-	ovs, err := libovsdb.Connect(*connection, nil)
+	ovs, err := libovsdb.Connect(*connection, "Open_vSwitch", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func list() {
 	populateCache(ovs, *final)
 }
 func run() {
-	ovs, err := libovsdb.Connect(*connection, nil)
+	ovs, err := libovsdb.Connect(*connection, "Open_vSwitch", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func populateCache(ovs *libovsdb.OvsdbClient, updates libovsdb.TableUpdates) {
 			empty := libovsdb.Row{}
 			if !reflect.DeepEqual(row.New, empty) {
 				if *api == "native" {
-					rowData, err := ovs.Apis["Open_vSwitch"].GetRowData(table, &row.New)
+					rowData, err := ovs.API.GetRowData(table, &row.New)
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -133,15 +133,15 @@ func deleteBridge(ovs *libovsdb.OvsdbClient, uuid string) {
 	var mutCondition []interface{}
 
 	if *api == "native" {
-		delCondition, err = ovs.Apis["Open_vSwitch"].NewCondition("Bridge", "_uuid", "==", uuid)
+		delCondition, err = ovs.API.NewCondition("Bridge", "_uuid", "==", uuid)
 		if err != nil {
 			log.Fatal(err)
 		}
-		mutation, err = ovs.Apis["Open_vSwitch"].NewMutation("Open_vSwitch", "bridges", "delete", []string{uuid})
+		mutation, err = ovs.API.NewMutation("Open_vSwitch", "bridges", "delete", []string{uuid})
 		if err != nil {
 			log.Fatal(err)
 		}
-		mutCondition, err = ovs.Apis["Open_vSwitch"].NewMutation("Open_vSwitch", "_uuid", "==", rootUUID)
+		mutCondition, err = ovs.API.NewMutation("Open_vSwitch", "_uuid", "==", rootUUID)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -198,7 +198,7 @@ func createBridge(ovs *libovsdb.OvsdbClient, iter int) {
 		bridge["datapath_id"] = datapathID
 		nbridge["external_ids"] = externalIds
 
-		bridge, err = ovs.Apis["Open_vSwitch"].NewRow("Bridge", nbridge)
+		bridge, err = ovs.API.NewRow("Bridge", nbridge)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -234,11 +234,11 @@ func createBridge(ovs *libovsdb.OvsdbClient, iter int) {
 	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
 	if *api == "native" {
 		// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
-		mutation, err = ovs.Apis["Open_vSwitch"].NewMutation("Open_vSwitch", "bridges", "insert", []string{namedUUID})
+		mutation, err = ovs.API.NewMutation("Open_vSwitch", "bridges", "insert", []string{namedUUID})
 		if err != nil {
 			log.Fatalf("Mutation Error: %s", err.Error())
 		}
-		condition, err = ovs.Apis["Open_vSwitch"].NewCondition("Open_vSwitch", "_uuid", "==", rootUUID)
+		condition, err = ovs.API.NewCondition("Open_vSwitch", "_uuid", "==", rootUUID)
 		if err != nil {
 			log.Fatalf("Condition Error: %s", err.Error())
 		}

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -274,10 +274,9 @@ func TestMonitor(t *testing.T) {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
 
-	reply, err := ovs.MonitorAll(nil)
-
-	if reply == nil || err != nil {
-		t.Error("Monitor operation failed with reply=", reply, " and error=", err)
+	err = ovs.MonitorAll(nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 	ovs.Disconnect()
 }
@@ -497,7 +496,10 @@ func TestMonitorCancel(t *testing.T) {
 			Modify:  true,
 		}}
 
-	_, _ = ovs.Monitor(monitorID, requests)
+	err = ovs.Monitor(monitorID, requests)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = ovs.MonitorCancel(monitorID)
 

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -12,6 +12,7 @@ import (
 const (
 	defOvsRunDir = "/var/run/openvswitch"
 	defOvsSocket = "db.sock"
+	defDB        = "Open_vSwitch"
 )
 
 var cfg *Config
@@ -46,14 +47,14 @@ func TestConnect(t *testing.T) {
 	go func() {
 		// Use Convenience params. Ignore failure even if any
 
-		_, err := Connect(cfg.Addr, nil)
+		_, err := Connect(cfg.Addr, defDB, nil)
 		if err != nil {
 			log.Println("Couldnt establish OVSDB connection with Defult params. No big deal")
 		}
 	}()
 
 	go func() {
-		ovs, err := Connect(cfg.Addr, nil)
+		ovs, err := Connect(cfg.Addr, defDB, nil)
 		if err != nil {
 			connected <- false
 		} else {
@@ -78,7 +79,7 @@ func TestListDbs(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -100,7 +101,7 @@ func TestListDbs(t *testing.T) {
 		t.Error("Expected: 'Open_vSwitch'", reply)
 	}
 	var b bytes.Buffer
-	ovs.Schema[reply[0]].Print(&b)
+	ovs.Schema.Print(&b)
 	ovs.Disconnect()
 }
 
@@ -110,7 +111,7 @@ func TestGetSchemas(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -138,7 +139,7 @@ func TestInsertTransact(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -212,7 +213,7 @@ func TestDeleteTransact(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -268,7 +269,7 @@ func TestMonitor(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -287,7 +288,7 @@ func TestNotify(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -318,7 +319,7 @@ func TestRemoveNotify(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -361,7 +362,7 @@ func TestDBSchemaValidation(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -389,7 +390,7 @@ func TestTableSchemaValidation(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -417,7 +418,7 @@ func TestColumnSchemaInRowValidation(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -447,7 +448,7 @@ func TestColumnSchemaInMultipleRowsValidation(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -482,7 +483,7 @@ func TestColumnSchemaValidation(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
@@ -507,7 +508,7 @@ func TestMonitorCancel(t *testing.T) {
 		t.Skip()
 	}
 
-	ovs, err := Connect(cfg.Addr, nil)
+	ovs, err := Connect(cfg.Addr, defDB, nil)
 	if err != nil {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -353,7 +353,7 @@ func (n Notifier) Stolen([]interface{}) {
 func (n Notifier) Echo([]interface{}) {
 	n.echoChan <- true
 }
-func (n Notifier) Disconnected(*OvsdbClient) {
+func (n Notifier) Disconnected() {
 }
 
 func TestTableSchemaValidation(t *testing.T) {

--- a/ovs_integration_test.go
+++ b/ovs_integration_test.go
@@ -180,7 +180,7 @@ func TestInsertTransact(t *testing.T) {
 	}
 
 	operations := []Operation{insertOp, mutateOp}
-	reply, err := ovs.Transact("Open_vSwitch", operations...)
+	reply, err := ovs.Transact(operations...)
 
 	if len(reply) < len(operations) {
 		t.Error("Number of Replies should be atleast equal to number of Operations")
@@ -242,7 +242,7 @@ func TestDeleteTransact(t *testing.T) {
 	}
 
 	operations := []Operation{deleteOp, mutateOp}
-	reply, err := ovs.Transact("Open_vSwitch", operations...)
+	reply, err := ovs.Transact(operations...)
 
 	if len(reply) < len(operations) {
 		t.Error("Number of Replies should be atleast equal to number of Operations")
@@ -274,7 +274,7 @@ func TestMonitor(t *testing.T) {
 		t.Fatalf("Failed to Connect. error: %s", err)
 	}
 
-	reply, err := ovs.MonitorAll("Open_vSwitch", nil)
+	reply, err := ovs.MonitorAll(nil)
 
 	if reply == nil || err != nil {
 		t.Error("Monitor operation failed with reply=", reply, " and error=", err)
@@ -356,34 +356,6 @@ func (n Notifier) Echo([]interface{}) {
 func (n Notifier) Disconnected(*OvsdbClient) {
 }
 
-func TestDBSchemaValidation(t *testing.T) {
-	SetConfig()
-	if testing.Short() {
-		t.Skip()
-	}
-
-	ovs, err := Connect(cfg.Addr, defDB, nil)
-	if err != nil {
-		t.Fatalf("Failed to Connect. error: %s", err)
-	}
-
-	bridge := make(map[string]interface{})
-	bridge["name"] = "docker-ovs"
-
-	operation := Operation{
-		Op:    "insert",
-		Table: "Bridge",
-		Row:   bridge,
-	}
-
-	_, err = ovs.Transact("Invalid_DB", operation)
-	if err == nil {
-		t.Error("Invalid DB operation Validation failed")
-	}
-
-	ovs.Disconnect()
-}
-
 func TestTableSchemaValidation(t *testing.T) {
 	SetConfig()
 	if testing.Short() {
@@ -403,7 +375,7 @@ func TestTableSchemaValidation(t *testing.T) {
 		Table: "InvalidTable",
 		Row:   bridge,
 	}
-	_, err = ovs.Transact("Open_vSwitch", operation)
+	_, err = ovs.Transact(operation)
 
 	if err == nil {
 		t.Error("Invalid Table Name Validation failed")
@@ -433,7 +405,7 @@ func TestColumnSchemaInRowValidation(t *testing.T) {
 		Row:   bridge,
 	}
 
-	_, err = ovs.Transact("Open_vSwitch", operation)
+	_, err = ovs.Transact(operation)
 
 	if err == nil {
 		t.Error("Invalid Column Name Validation failed")
@@ -468,7 +440,7 @@ func TestColumnSchemaInMultipleRowsValidation(t *testing.T) {
 		Table: "Bridge",
 		Rows:  rows,
 	}
-	_, err = ovs.Transact("Open_vSwitch", operation)
+	_, err = ovs.Transact(operation)
 
 	if err == nil {
 		t.Error("Invalid Column Name Validation failed")
@@ -493,7 +465,7 @@ func TestColumnSchemaValidation(t *testing.T) {
 		Table:   "Bridge",
 		Columns: []string{"name", "invalidColumn"},
 	}
-	_, err = ovs.Transact("Open_vSwitch", operation)
+	_, err = ovs.Transact(operation)
 
 	if err == nil {
 		t.Error("Invalid Column Name Validation failed")
@@ -525,7 +497,7 @@ func TestMonitorCancel(t *testing.T) {
 			Modify:  true,
 		}}
 
-	_, _ = ovs.Monitor("Open_vSwitch", monitorID, requests)
+	_, _ = ovs.Monitor(monitorID, requests)
 
 	err = ovs.MonitorCancel(monitorID)
 


### PR DESCRIPTION
This makes a few significant API changes in order to provide a cache for monitor updates.
Not only does it improve the API, but it also makes it possible to implement a `Get` (from cache) in the ORM API proposed in #31 

The API changes are as follows:

1. Restrict the client to have only one DatabaseSchema. This mirrors how ovsdb-server is run in the wild (even though techincally a server can support multiple schemas). This has the advantage of removing the `database` argument from the `Transact`, `Monitor`... APIs
1. Replace `Disconnected(*OvsClient)` with `Disconnected()`.The client needs to know about a handler to register it, but the handler shouldn't need to know about the client. Even if it did, that could be achieved through channels. Either way, the Go compiler didn't seem to like passing that client around once I'd added the cache feature.

The feature itself can be seen in operation in the `play_with_ovs` example.

In short, the `OvsClient` exposes a `Cache` and associated handler to ensure the cache is updated.
As such, a user can call `Monitor` without a handler defined and the initial state and all updates will populate in to the cache.

The cache API is very simple:

```go
# Get a list of all tables
client.Cache.Tables()

# Get a table
client.Cache.Table("Open_vSwitch")

# Get a list of all row uuids in a table
client.Cache.Tables("Open_vSwitch").Rows()

# Get a row in a table by UUID
client.Cache.Tables("Open_vSwitch").Row("uuid")
```

In addition, a user may choose to register a calback so they can perform an action when a cache item is updated:

```go
ovs.Cache.AddEventHandler(&libovsdb.EventHandlerFuncs{
AddFunc: func(table string, row libovsdb.Row) {
	if table == bridgeTable {
		update <- row
	}
},
})
```

Misc changes included in this PR to make sure CI is green:

1. Fix linting/formatting of `encoding_test.go`
2. Fix play_with_ovs which was a case of `s/"ovsTable"/ovsTable/g`

/cc @amorenoz @hzhou8 